### PR TITLE
New Ecto Cast Error Defaults to 404 Error

### DIFF
--- a/lib/op_error/format.ex
+++ b/lib/op_error/format.ex
@@ -7,6 +7,7 @@ defmodule OpError.Format do
   """
 
   @default_404_errors [
+    Ecto.Query.CastError,
     Ecto.CastError,
     Ecto.NoResultsError,
     Phoenix.Router.NoRouteError

--- a/test/controller/default_error_controller_test.exs
+++ b/test/controller/default_error_controller_test.exs
@@ -10,6 +10,15 @@ defmodule DefaultErrorControllerTest do
     assert error["detail"] == ""
   end
 
+  test "GET /default/cast_error" do
+    conn = get build_conn, "/default/cast_error"
+    %{"errors" => [error]} = json_response(conn, 404)
+
+    assert error["title"] == "Resource Not Found"
+    assert error["status"] == "404"
+    assert error["detail"] == ""
+  end
+
   test "get /default/500" do
     conn = get build_conn, "/default/500"
     %{"errors" => [error]} = json_response(conn, 500)

--- a/test/support/controller/default_error_controller.exs
+++ b/test/support/controller/default_error_controller.exs
@@ -5,6 +5,13 @@ defmodule Test.DefaultErrorController do
     raise Ecto.NoResultsError, queryable: "nope"
   end
 
+  def cast_error(_conn, _params) do
+    raise Ecto.Query.CastError,
+      message: "can't even cast it bro",
+      type: "meh",
+      value: "whatever"
+  end
+
   def five_oh_oh(_conn, _params) do
     raise "Not What I Expected"
   end

--- a/test/support/router.exs
+++ b/test/support/router.exs
@@ -13,6 +13,7 @@ defmodule Test.Router do
 
     get "/default/404", Test.DefaultErrorController, :four_oh_four
     get "/default/500", Test.DefaultErrorController, :five_oh_oh
+    get "/default/cast_error", Test.DefaultErrorController, :cast_error
 
     get "/custom/nope", Test.CustomErrorController, :private_access
     get "/custom/boom", Test.CustomErrorController, :problematic_call


### PR DESCRIPTION
If you upgrade to ecto 2 there is a new cast error which you normally
would want to be cast as a 404 error.  This is done by default now
for you.