### PR TITLE
Add RequestId as `id` for Error

### DIFF
--- a/lib/op_error/view.ex
+++ b/lib/op_error/view.ex
@@ -10,9 +10,10 @@ defmodule OpError.View do
     %{ errors: [ format(error) ] }
   end
 
-  defp format(%{status: status}=error) do
+  defp format(%{status: status, error_id: id}=error) do
     error
     |> Map.take([:status, :title, :detail])
     |> Map.put(:status, "#{status}")
+    |> Map.put(:id, id)
   end
 end

--- a/test/controller/custom_error_controller_test.exs
+++ b/test/controller/custom_error_controller_test.exs
@@ -8,6 +8,7 @@ defmodule CustomErrorControllerTest do
     assert error["title"] == "Access Denied"
     assert error["status"] == "401"
     assert error["detail"] == "You do not have access to this!"
+    assert error["id"] in Plug.Conn.get_resp_header(conn, "some-special-id")
   end
 
   test "GET /custom/boom" do
@@ -17,5 +18,6 @@ defmodule CustomErrorControllerTest do
     assert error["title"] == "Internal Error"
     assert error["status"] == "500"
     assert error["detail"] == ""
+    assert error["id"] in Plug.Conn.get_resp_header(conn, "some-special-id")
   end
 end

--- a/test/controller/default_error_controller_test.exs
+++ b/test/controller/default_error_controller_test.exs
@@ -8,6 +8,7 @@ defmodule DefaultErrorControllerTest do
     assert error["title"] == "Resource Not Found"
     assert error["status"] == "404"
     assert error["detail"] == ""
+    assert error["id"] in Plug.Conn.get_resp_header(conn, "x-request-id")
   end
 
   test "GET /default/cast_error" do
@@ -17,6 +18,7 @@ defmodule DefaultErrorControllerTest do
     assert error["title"] == "Resource Not Found"
     assert error["status"] == "404"
     assert error["detail"] == ""
+    assert error["id"] in Plug.Conn.get_resp_header(conn, "x-request-id")
   end
 
   test "get /default/500" do
@@ -26,5 +28,6 @@ defmodule DefaultErrorControllerTest do
     assert error["title"] == "Not What I Expected"
     assert error["status"] == "500"
     assert error["detail"] == ""
+    assert error["id"] in Plug.Conn.get_resp_header(conn, "x-request-id")
   end
 end

--- a/test/support/router.exs
+++ b/test/support/router.exs
@@ -6,16 +6,29 @@ defmodule Test.Router do
     plug :accepts, ~w(json)
   end
 
+  pipeline :custom do
+    plug :accepts, ~w(json)
+    plug Plug.RequestId, http_header: "some-special-id"
+  end
+
+  scope "/default" do
+    pipe_through :api
+
+    get "/404", Test.DefaultErrorController, :four_oh_four
+    get "/500", Test.DefaultErrorController, :five_oh_oh
+    get "/cast_error", Test.DefaultErrorController, :cast_error
+  end
+
+  scope "/custom" do
+    pipe_through :custom
+
+    get "/nope", Test.CustomErrorController, :private_access
+    get "/boom", Test.CustomErrorController, :problematic_call
+  end
+
   scope "/" do
     pipe_through :api
 
     get "/smoke", Test.SmokeController, :smoke
-
-    get "/default/404", Test.DefaultErrorController, :four_oh_four
-    get "/default/500", Test.DefaultErrorController, :five_oh_oh
-    get "/default/cast_error", Test.DefaultErrorController, :cast_error
-
-    get "/custom/nope", Test.CustomErrorController, :private_access
-    get "/custom/boom", Test.CustomErrorController, :problematic_call
   end
 end

--- a/test/support/web.exs
+++ b/test/support/web.exs
@@ -9,7 +9,7 @@ defmodule Test.Web do
   def controller_custom do
     quote do
       use Phoenix.Controller, namespace: Test
-      use OpError.Plug, format: Test.CustomFormat
+      use OpError.Plug, format: Test.CustomFormat, request_id: "some-special-id"
     end
   end
 


### PR DESCRIPTION
To help make errors more traceable from a user's perspective we
would like to be able for the api user to issue the id of the
error they got when debugging so we could then look through our
logs for this error.

This uses the built in `Plug.RequestId` plug that ships with
Phoenix to help bring that id forward.  It is overrideable via
specifying the `request_id` and using the same token that is
set for the aforementioned plug.